### PR TITLE
Divide list of versions into the actual version and release name of MacOS

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -85,13 +85,13 @@ kubectl apply -f kubernetes.yml
 
   Select from the values below:
   
-  |   **Value** | **Version**    |
-  |----|-----|
-  | `sequoia`    | macOS Sequoia   |
-  | `sonoma`    | macOS Sonoma   |
-  | `ventura`   | macOS Ventura  |
-  | `monterey`  | macOS Monterey |
-  | `big-sur`   | macOS Big Sur  |
+  |   **Value** | **Version**    | **Release Name** |
+  |-------------|----------------|------------------|
+  | `sequoia`   | macOS 15       | Sequoia          |
+  | `sonoma`    | macOS 14       | Sonoma           |
+  | `ventura`   | macOS 13       | Ventura          |
+  | `monterey`  | macOS 12       | Monterey         |
+  | `big-sur`   | macOS 11       | Big Sur          |
 
 ### How do I change the storage location?
 


### PR DESCRIPTION
Based on https://en.wikipedia.org/wiki/MacOS_version_history

This doesn't look like a big deal, but i am always confused when it comes to "release names" and prefer the versions a lot more. I can never tell what MacOS Sonoma or Ubuntu Noble Numbat are, but i can tell you exactly which workarounds we have implemented when you tell me its MacOS 14 and Ubuntu 24.04.

Maybe i am just bad with names. With this change it gets a bit better.