### PR TITLE
Fix: Container Can Gain Elevated System Privileges Without Proper Restrictions in kubernetes.yml

### DIFF
--- a/kubernetes.yml
+++ b/kubernetes.yml
@@ -29,6 +29,8 @@ spec:
       containers:
       - name: macos
         image: dockurr/macos
+        securityContext:
+          allowPrivilegeEscalation: false
         env:
         - name: VERSION
           value: "13"


### PR DESCRIPTION
**Context and Purpose:**

This PR automatically remediates a security vulnerability:
- **Description:** In Kubernetes, each pod runs in its own isolated environment with its own set of security policies. However, certain container images may contain `setuid` or `setgid` binaries that could allow an attacker to perform privilege escalation and gain access to sensitive resources. To mitigate this risk, it's recommended to add a `securityContext` to the container in the pod, with the parameter `allowPrivilegeEscalation` set to `false`. This will prevent the container from running any privileged processes and limit the impact of any potential attacks. By adding the `allowPrivilegeEscalation` parameter to your the `securityContext`, you can help to ensure that your containerized applications are more secure and less vulnerable to privilege escalation attacks.
- **Rule ID:** yaml.kubernetes.security.allow-privilege-escalation.allow-privilege-escalation
- **Severity:** MEDIUM
- **File:** kubernetes.yml
- **Lines Affected:** 44 - 44

This change is necessary to protect the application from potential security risks associated with this vulnerability.

**Solution Implemented:**

The automated remediation process has applied the necessary changes to the affected code in `kubernetes.yml` to resolve the identified issue.

Please review the changes to ensure they are correct and integrate as expected.