### PR TITLE
fix: Add read-write permission to docker volume

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -14,6 +14,6 @@ services:
       - 5900:5900/tcp
       - 5900:5900/udp
     volumes:
-      - ./macos:/storage
+      - ./macos:/storage:rw
     restart: always
     stop_grace_period: 2m

--- a/readme.md
+++ b/readme.md
@@ -41,7 +41,7 @@ services:
       - 5900:5900/tcp
       - 5900:5900/udp
     volumes:
-      - ./macos:/storage
+      - ./macos:/storage:rw
     restart: always
     stop_grace_period: 2m
 ```
@@ -49,7 +49,7 @@ services:
 ##### Via Docker CLI:
 
 ```bash
-docker run -it --rm --name macos -p 8006:8006 --device=/dev/kvm --device=/dev/net/tun --cap-add NET_ADMIN -v "${PWD:-.}/macos:/storage" --stop-timeout 120 dockurr/macos
+docker run -it --rm --name macos -p 8006:8006 --device=/dev/kvm --device=/dev/net/tun --cap-add NET_ADMIN -v "${PWD:-.}/macos:/storage:rw" --stop-timeout 120 dockurr/macos
 ```
 
 ##### Via Kubernetes:
@@ -110,7 +110,7 @@ kubectl apply -f https://raw.githubusercontent.com/dockur/macos/refs/heads/maste
 
   ```yaml
   volumes:
-    - ./macos:/storage
+    - ./macos:/storage:rw
   ```
 
   Replace the example path `./macos` with the desired storage folder or named volume.
@@ -220,7 +220,7 @@ kubectl apply -f https://raw.githubusercontent.com/dockur/macos/refs/heads/maste
 
   ```yaml
   volumes:
-    - ./example:/shared
+    - ./example:/shared:rw
   ```
 
   Then start macOS and execute the following command:


### PR DESCRIPTION
Fixes a permission denied error when using SELinux (for example on Fedora)

Without this, after downloading the recovery image, the error:
```
mv: cannot create regular file '/storage/base.dmg': Permission denied
install.sh: line 147: /storage/macos.version: Permission denied
```
and the recovery will download again and again.

":Z" should also work, but “:rw” works without any problems.