### PR TITLE
Fix table formatting in readme.md and adding support for macOS 26 Tahoe

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -99,8 +99,9 @@ kubectl apply -f https://raw.githubusercontent.com/dockur/macos/refs/heads/maste
 
   Select from the values below:
   
-  |   **Value** | **Version**    | **Name** |
+  |   **Value** | **Version**    | **Name**         |
   |-------------|----------------|------------------|
+  | `26`        | macOS 26       | Tahoe            |
   | `15`        | macOS 15       | Sequoia          |
   | `14`        | macOS 14       | Sonoma           |
   | `13`        | macOS 13       | Ventura          |


### PR DESCRIPTION
I changed the Version number to 26 and was able to successfully fetch the macOS 26 Tahoe recovery image and install the latest version of macOS. But there is only one problem with the latest version. The issue is the keyboard layout mess-up, which causes a random layout to be used other than the US keyboard.

It is recommended to change the keyboard layout in the lock screen before entering the password. Once inside the home screen, I would recommend removing all keyboard layouts other than the user's preferred one from the system settings to avoid getting locked out of your system.